### PR TITLE
[CALCITE] Changed Map<Keyword, String> to Map<String, Keyword>

### DIFF
--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
@@ -19,6 +19,7 @@ package org.apache.calcite.buildtools.parser;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -73,9 +74,9 @@ public class DialectGenerate {
    * @throws IllegalStateException If a nonReservedKeyword is not also a keyword
    */
   public void validateNonReservedKeywords(final ExtractedData extractedData) {
-    for (Keyword keyword : extractedData.nonReservedKeywords) {
+    for (String keyword : extractedData.nonReservedKeywords.keySet()) {
       if (!extractedData.keywords.containsKey(keyword)) {
-        throw new IllegalStateException(keyword.keyword + " is not a keyword.");
+        throw new IllegalStateException(keyword + " is not a keyword.");
       }
     }
   }
@@ -101,7 +102,7 @@ public class DialectGenerate {
    *
    * @return The formatted string
    */
-  public String unparseTokenAssignment(Map<Keyword, String> map) {
+  public String unparseTokenAssignment(Map<String, Keyword> map) {
     if (map.isEmpty()) {
       return "";
     }
@@ -110,11 +111,11 @@ public class DialectGenerate {
     stringBuilder.append("<DEFAULT, DQID, BTID> TOKEN :\n{\n");
     String tokenTemplate = "< %s: %s >";
     List<String> tokens = new ArrayList<>();
-    for (Map.Entry<Keyword, String> entry : map.entrySet()) {
+    for (Map.Entry<String, Keyword> entry : map.entrySet()) {
       StringBuilder tokenBuilder = new StringBuilder();
-      Keyword keyword = entry.getKey();
+      Keyword keyword = entry.getValue();
       tokenBuilder.append(String.format(tokenTemplate, keyword.keyword,
-          entry.getValue()));
+            keyword.value));
       if (keyword.filePath == null) {
         tokenBuilder.append(" // No file specified.");
       } else {
@@ -158,7 +159,8 @@ public class DialectGenerate {
    *                      data
    */
   public void unparseNonReservedKeywords(ExtractedData extractedData) {
-    final ArrayList<Set<Keyword>> partitions = getPartitions(extractedData.nonReservedKeywords);
+    final ArrayList<Set<Keyword>> partitions =
+      getPartitions(new LinkedHashSet<Keyword>(extractedData.nonReservedKeywords.values()));
     final int numPartitions = partitions.size();
     final String functionNameTemplate = "NonReservedKeyword%dof" + numPartitions;
     final StringBuilder bodyBuilder = new StringBuilder();

--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
@@ -19,7 +19,6 @@ package org.apache.calcite.buildtools.parser;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -111,9 +110,8 @@ public class DialectGenerate {
     stringBuilder.append("<DEFAULT, DQID, BTID> TOKEN :\n{\n");
     String tokenTemplate = "< %s: %s >";
     List<String> tokens = new ArrayList<>();
-    for (Map.Entry<String, Keyword> entry : map.entrySet()) {
+    for (Keyword keyword : map.values()) {
       StringBuilder tokenBuilder = new StringBuilder();
-      Keyword keyword = entry.getValue();
       tokenBuilder.append(String.format(tokenTemplate, keyword.keyword,
             keyword.value));
       if (keyword.filePath == null) {

--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
@@ -160,7 +160,8 @@ public class DialectGenerate {
    */
   public void unparseNonReservedKeywords(ExtractedData extractedData) {
     final ArrayList<Set<Keyword>> partitions =
-      getPartitions(new LinkedHashSet<Keyword>(extractedData.nonReservedKeywords.values()));
+      getPartitions(
+          new LinkedHashSet<>(extractedData.nonReservedKeywords.values()));
     final int numPartitions = partitions.size();
     final String functionNameTemplate = "NonReservedKeyword%dof" + numPartitions;
     final StringBuilder bodyBuilder = new StringBuilder();

--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectTraverser.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectTraverser.java
@@ -27,11 +27,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.Set;
 
 
 /**
@@ -229,13 +227,13 @@ public class DialectTraverser {
   }
 
   /**
-   * Parses the {@code lines} array into a {@code Set<Keyword>}. Empty lines
-   * are skipped.
+   * Parses the {@code lines} array into a {@code Map<String, Keyword>}.
+   * Empty lines are skipped.
    *
    * @param lines The lines to parse
    * @param filePath The file these lines are from
    *
-   * @return The parsed lines as a {@code Set<Keyword>}
+   * @return The parsed lines as a {@code Map<String, Keyword>}
    */
   private static Map<String, Keyword> processNonReservedKeywords(String[] lines,
       String filePath) {

--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectTraverser.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectTraverser.java
@@ -209,13 +209,13 @@ public class DialectTraverser {
           String[] lines = fileText.split("\n");
           if (fileName.equals("nonReservedKeywords.txt")) {
             extractedData.nonReservedKeywords
-              .addAll(processNonReservedKeywords(lines, filePath));
+              .putAll(processNonReservedKeywords(lines, filePath));
           } else if (fileName.equals("keywords.txt")) {
-            addOrReplaceEntries(extractedData.keywords,
-                processKeyValuePairs(lines, filePath));
+            extractedData.keywords
+              .putAll(processKeyValuePairs(lines, filePath));
           } else if (fileName.equals("identifiers.txt")) {
-            addOrReplaceEntries(extractedData.identifiers,
-                processKeyValuePairs(lines, filePath));
+            extractedData.identifiers
+              .putAll(processKeyValuePairs(lines, filePath));
           }
         }
       } else if (!directories.isEmpty() && fileName.equals(nextDirectory)) {
@@ -229,27 +229,6 @@ public class DialectTraverser {
   }
 
   /**
-   * Adds all of the elements in {@code sourceMap} to {@code mainMap}. If a key
-   * is already present in {@code mainMap} it is removed before being updated.
-   * This is done to ensure that the {@code filePath} gets updated if a given
-   * keyword has been overridden.
-   *
-   * @param mainMap The map that is getting entries added to it
-   * @param sourceMap The map whose entries are being added from
-   */
-  private static void addOrReplaceEntries(Map<Keyword, String> mainMap,
-      final Map<Keyword, String> sourceMap) {
-    for (Map.Entry<Keyword, String> entry : sourceMap.entrySet()) {
-      Keyword key = entry.getKey();
-      String value = entry.getValue();
-      if (mainMap.containsKey(key)) {
-        mainMap.remove(key);
-      }
-      mainMap.put(key, value);
-    }
-  }
-
-  /**
    * Parses the {@code lines} array into a {@code Set<Keyword>}. Empty lines
    * are skipped.
    *
@@ -258,13 +237,13 @@ public class DialectTraverser {
    *
    * @return The parsed lines as a {@code Set<Keyword>}
    */
-  private static Set<Keyword> processNonReservedKeywords(String[] lines,
+  private static Map<String, Keyword> processNonReservedKeywords(String[] lines,
       String filePath) {
-    Set<Keyword> nonReservedKeywords = new LinkedHashSet<>();
+    Map<String, Keyword> nonReservedKeywords = new LinkedHashMap<>();
     for (String line : lines) {
       line = line.trim();
       if (!line.isEmpty()) {
-        nonReservedKeywords.add(new Keyword(line, filePath));
+        nonReservedKeywords.put(line, new Keyword(line, line, filePath));
       }
     }
     return nonReservedKeywords;
@@ -280,18 +259,18 @@ public class DialectTraverser {
    *
    * @return The {@code Map<Keyword, String>} containing the parsed lines
    */
-  private static Map<Keyword, String> processKeyValuePairs(String[] lines,
+  private static Map<String, Keyword> processKeyValuePairs(String[] lines,
       String filePath) {
-    Map<Keyword, String> map = new LinkedHashMap<>();
+    Map<String, Keyword> map = new LinkedHashMap<>();
     for (String line : lines) {
       line = line.trim();
       if (line.isEmpty()) {
         continue;
       }
       int colonIndex = line.indexOf(":");
-      String key = line.substring(0, colonIndex);
-      String value = line.substring(colonIndex + 1);
-      map.put(new Keyword(key.trim(), filePath), value.trim());
+      String keyword = line.substring(0, colonIndex).trim();
+      String value = line.substring(colonIndex + 1).trim();
+      map.put(keyword, new Keyword(keyword, value, filePath));
     }
     return map;
   }

--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/ExtractedData.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/ExtractedData.java
@@ -18,24 +18,22 @@ package org.apache.calcite.buildtools.parser;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A simple container class to hold the data extracted from files.
  */
 public class ExtractedData {
-  public final Map<Keyword, String> keywords;
-  public final Set<Keyword> nonReservedKeywords;
-  public final Map<Keyword, String> identifiers;
+  public final Map<String, Keyword> keywords;
+  public final Map<String, Keyword> nonReservedKeywords;
+  public final Map<String, Keyword> identifiers;
   public final Map<String, String> functions;
   public final List<String> tokenAssignments;
 
   public ExtractedData() {
     keywords = new LinkedHashMap<>();
-    nonReservedKeywords = new LinkedHashSet<>();
+    nonReservedKeywords = new LinkedHashMap<>();
     identifiers = new LinkedHashMap<>();
     functions = new LinkedHashMap<>();
     tokenAssignments = new ArrayList<>();

--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/Keyword.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/Keyword.java
@@ -24,10 +24,15 @@ import java.util.Objects;
  */
 public class Keyword {
   public final String keyword;
+  public final String value;
   public final String filePath;
 
   public Keyword(String keyword) {
-    this(keyword, /*filePath=*/ null);
+    this(keyword, keyword, /*filePath=*/ null);
+  }
+
+  public Keyword(String keyword, String value) {
+    this(keyword, value, /*filePath=*/ null);
   }
 
   /**
@@ -36,8 +41,9 @@ public class Keyword {
    * @param keyword The keyword string
    * @param filePath The file where this keyword was taken from
    */
-  public Keyword(String keyword, String filePath) {
+  public Keyword(String keyword, String value, String filePath) {
     this.keyword = Objects.requireNonNull(keyword.toUpperCase());
+    this.value = Objects.requireNonNull(value);
     this.filePath = filePath;
   }
 

--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/Keyword.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/Keyword.java
@@ -38,7 +38,8 @@ public class Keyword {
   /**
    * Creates a {@code Keyword}.
    *
-   * @param keyword The keyword string
+   * @param keyword The name of the keyword
+   * @param value The value of the keyword
    * @param filePath The file where this keyword was taken from
    */
   public Keyword(String keyword, String value, String filePath) {
@@ -48,8 +49,11 @@ public class Keyword {
   }
 
   @Override public int hashCode() {
-    // The filePath should not be considered when calculating hashCode.
-    return keyword.hashCode();
+    int hashCode = keyword.hashCode() * value.hashCode();
+    if (filePath != null) {
+      hashCode *= filePath.hashCode();
+    }
+    return hashCode;
   }
 
   @Override public boolean equals(Object obj) {
@@ -57,7 +61,13 @@ public class Keyword {
       return false;
     }
     Keyword other = (Keyword) obj;
-    // The filePath should not be considered when checking for equality.
-    return this.keyword.equals(other.keyword);
+    if (!this.keyword.equals(other.keyword) && !this.value.equals(other.value)) {
+      return false;
+    }
+    if (this.filePath == null && other.filePath == null) {
+      return true;
+    }
+    return this.filePath != null && other.filePath != null
+        && this.filePath.equals(other.filePath);
   }
 }

--- a/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
+++ b/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
@@ -321,7 +321,7 @@ public class DialectGenerateTest {
     Map<String, Keyword> keywords = new LinkedHashMap<>();
     DialectGenerate dialectGenerate = new DialectGenerate();
     keywords.put("foo", new Keyword("foo", "\"FOO\"", "path/file"));
-    keywords.put("bar", new Keyword("bar",  "\"BAR\""));
+    keywords.put("bar", new Keyword("bar", "\"BAR\""));
     keywords.put("baz", new Keyword("baz", "\"BAZ\"", "path/file"));
     String actual = dialectGenerate.unparseTokenAssignment(keywords);
     String expected = "// Auto generated.\n"
@@ -335,7 +335,7 @@ public class DialectGenerateTest {
   }
 
   @Test public void testPartitionFunctionSingle() {
-    Map<String, Keyword> keywords = new LinkedHashMap<String, Keyword>();
+    Map<String, Keyword> keywords = new LinkedHashMap<>();
     DialectGenerate dialectGenerate = new DialectGenerate();
     keywords.put("foo", new Keyword("foo", "foo", "path/file"));
     String actual = dialectGenerate.getPartitionFunction("void func():",
@@ -349,7 +349,7 @@ public class DialectGenerateTest {
   }
 
   @Test public void testPartitionFunctionMultiple() {
-    Map<String, Keyword> keywords = new LinkedHashMap<String, Keyword>();
+    Map<String, Keyword> keywords = new LinkedHashMap<>();
     DialectGenerate dialectGenerate = new DialectGenerate();
     keywords.put("foo", new Keyword("foo", "foo", "path/file"));
     keywords.put("bar", new Keyword("bar", "bar"));

--- a/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
+++ b/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
@@ -284,30 +284,30 @@ public class DialectGenerateTest {
 
   @Test public void testNonReservedKeywordsValidNonEmpty() {
     ExtractedData extractedData = new ExtractedData();
-    extractedData.keywords.put(new Keyword("foo"), "\"foo\"");
-    extractedData.keywords.put(new Keyword("bar"), "\"bar\"");
-    extractedData.nonReservedKeywords.add(new Keyword("bar"));
+    extractedData.keywords.put("foo", new Keyword("foo"));
+    extractedData.keywords.put("bar", new Keyword("bar"));
+    extractedData.nonReservedKeywords.put("bar", new Keyword("bar"));
     assertNonReservedKeywordsValid(extractedData);
   }
 
   @Test public void testProcessKeywordsInvalidNonReservedKeywordFails() {
     ExtractedData extractedData = new ExtractedData();
-    extractedData.keywords.put(new Keyword("foo"), "\"foo\"");
-    extractedData.nonReservedKeywords.add(new Keyword("\"bar\""));
+    extractedData.keywords.put("foo", new Keyword("foo"));
+    extractedData.nonReservedKeywords.put("bar", new Keyword("bar"));
     assertNonReservedKeywordsInvalid(extractedData);
   }
 
   @Test public void testUnparseTokenAssignmentEmpty() {
-    Map<Keyword, String> keywords = new LinkedHashMap<>();
+    Map<String, Keyword> keywords = new LinkedHashMap<>();
     DialectGenerate dialectGenerate = new DialectGenerate();
     String actual = dialectGenerate.unparseTokenAssignment(keywords);
     assertEquals("", actual);
   }
 
   @Test public void testUnparseTokenAssignmentSingle() {
-    Map<Keyword, String> keywords = new LinkedHashMap<>();
+    Map<String, Keyword> keywords = new LinkedHashMap<>();
     DialectGenerate dialectGenerate = new DialectGenerate();
-    keywords.put(new Keyword("foo", "path/file"), "\"FOO\"");
+    keywords.put("foo", new Keyword("foo", "\"FOO\"", "path/file"));
     String actual = dialectGenerate.unparseTokenAssignment(keywords);
     String expected = "// Auto generated.\n"
          + "<DEFAULT, DQID, BTID> TOKEN :\n"
@@ -318,11 +318,11 @@ public class DialectGenerateTest {
   }
 
   @Test public void testUnparseTokenAssignmentMultiple() {
-    Map<Keyword, String> keywords = new LinkedHashMap<>();
+    Map<String, Keyword> keywords = new LinkedHashMap<>();
     DialectGenerate dialectGenerate = new DialectGenerate();
-    keywords.put(new Keyword("foo", "path/file"), "\"FOO\"");
-    keywords.put(new Keyword("bar", /*filePath=*/ null), "\"BAR\"");
-    keywords.put(new Keyword("baz", "path/file"), "\"BAZ\"");
+    keywords.put("foo", new Keyword("foo", "\"FOO\"", "path/file"));
+    keywords.put("bar", new Keyword("bar",  "\"BAR\""));
+    keywords.put("baz", new Keyword("baz", "\"BAZ\"", "path/file"));
     String actual = dialectGenerate.unparseTokenAssignment(keywords);
     String expected = "// Auto generated.\n"
          + "<DEFAULT, DQID, BTID> TOKEN :\n"
@@ -335,10 +335,11 @@ public class DialectGenerateTest {
   }
 
   @Test public void testPartitionFunctionSingle() {
-    Set<Keyword> keywords = new HashSet<Keyword>();
+    Map<String, Keyword> keywords = new LinkedHashMap<String, Keyword>();
     DialectGenerate dialectGenerate = new DialectGenerate();
-    keywords.add(new Keyword("foo", "path/file"));
-    String actual = dialectGenerate.getPartitionFunction("void func():", keywords);
+    keywords.put("foo", new Keyword("foo", "foo", "path/file"));
+    String actual = dialectGenerate.getPartitionFunction("void func():",
+        new LinkedHashSet<>(keywords.values()));
     String expected = "// Auto generated.\n"
          + "void func():\n"
          + "{\n}\n{\n"
@@ -348,12 +349,13 @@ public class DialectGenerateTest {
   }
 
   @Test public void testPartitionFunctionMultiple() {
-    Set<Keyword> keywords = new LinkedHashSet<Keyword>();
+    Map<String, Keyword> keywords = new LinkedHashMap<String, Keyword>();
     DialectGenerate dialectGenerate = new DialectGenerate();
-    keywords.add(new Keyword("foo", "path/file"));
-    keywords.add(new Keyword("bar", /*filePath=*/ null));
-    keywords.add(new Keyword("baz", "intermediate/path/file"));
-    String actual = dialectGenerate.getPartitionFunction("void func():", keywords);
+    keywords.put("foo", new Keyword("foo", "foo", "path/file"));
+    keywords.put("bar", new Keyword("bar", "bar"));
+    keywords.put("baz", new Keyword("baz", "baz", "intermediate/path/file"));
+    String actual = dialectGenerate.getPartitionFunction("void func():",
+       new LinkedHashSet<>(keywords.values()));
     String expected = "// Auto generated.\n"
          + "void func():\n"
          + "{\n}\n{\n"
@@ -383,7 +385,7 @@ public class DialectGenerateTest {
   @Test public void testUnparseNonReservedKeywordsSinglePartition() {
     ExtractedData extractedData = new ExtractedData();
     DialectGenerate dialectGenerate = new DialectGenerate();
-    extractedData.nonReservedKeywords.add(new Keyword("foo"));
+    extractedData.nonReservedKeywords.put("foo", new Keyword("foo"));
     dialectGenerate.unparseNonReservedKeywords(extractedData);
     assertEquals(2, extractedData.functions.size());
     assertTrue(extractedData.functions.containsKey("NonReservedKeyword"));
@@ -404,7 +406,8 @@ public class DialectGenerateTest {
     ExtractedData extractedData = new ExtractedData();
     DialectGenerate dialectGenerate = new DialectGenerate();
     for (int i = 0; i < DialectGenerate.PARTITION_SIZE + 1; i++) {
-      extractedData.nonReservedKeywords.add(new Keyword("foo" + i));
+      String key = "foo" + i;
+      extractedData.nonReservedKeywords.put(key, new Keyword(key));
     }
     dialectGenerate.unparseNonReservedKeywords(extractedData);
     assertEquals(3, extractedData.functions.size());

--- a/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/KeywordTest.java
+++ b/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/KeywordTest.java
@@ -26,24 +26,34 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class KeywordTest {
 
   @Test public void testHashCodeEquality() {
-    Keyword a = new Keyword("foo");
-    Keyword b = new Keyword("foo", "path/file");
+    Keyword a = new Keyword("foo", "foo", /*filePath=*/ null);
+    Keyword b = new Keyword("foo", "foo", /*filePath=*/ null);
     assertEquals(a.hashCode(), b.hashCode());
+    Keyword c = new Keyword("foo", "foo", "path");
+    Keyword d = new Keyword("foo", "foo", "path");
+    assertEquals(c.hashCode(), d.hashCode());
   }
 
   @Test public void testHashCodeInequality() {
     Keyword a = new Keyword("foo");
     Keyword b = new Keyword("bar");
     assertNotEquals(a.hashCode(), b.hashCode());
+    Keyword c = new Keyword("foo", "foo", null);
+    Keyword d = new Keyword("foo", "foo", "path");
+    assertNotEquals(c.hashCode(), d.hashCode());
   }
 
   @Test public void testEquality() {
     Keyword a = new Keyword("foo");
-    Keyword b = new Keyword("foo", "path/file");
-    Keyword c = new Keyword("FOO");
+    Keyword b = new Keyword("FOO");
     assertEquals(a, a);
     assertEquals(a, b);
-    assertEquals(a, c);
+    Keyword c = new Keyword("foo", "foo", "path");
+    Keyword d = new Keyword("foo", "foo", "path");
+    assertEquals(c, d);
+    Keyword e = new Keyword("foo", "foo", null);
+    Keyword f = new Keyword("foo", "foo", null);
+    assertEquals(e, f);
   }
 
   @Test public void testInequality() {
@@ -51,6 +61,9 @@ public class KeywordTest {
     Keyword b = new Keyword("bar");
     assertNotEquals(a, b);
     assertNotEquals(a, null);
+    Keyword c = new Keyword("foo", "foo", null);
+    Keyword d = new Keyword("foo", "foo", "path");
+    assertNotEquals(c, d);
   }
 
   @Test public void testKeywordGetsCapitalized() {

--- a/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/KeywordTest.java
+++ b/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/KeywordTest.java
@@ -38,7 +38,7 @@ public class KeywordTest {
     Keyword a = new Keyword("foo");
     Keyword b = new Keyword("bar");
     assertNotEquals(a.hashCode(), b.hashCode());
-    Keyword c = new Keyword("foo", "foo", null);
+    Keyword c = new Keyword("foo", "foo", /*filePath=*/ null);
     Keyword d = new Keyword("foo", "foo", "path");
     assertNotEquals(c.hashCode(), d.hashCode());
   }
@@ -51,8 +51,8 @@ public class KeywordTest {
     Keyword c = new Keyword("foo", "foo", "path");
     Keyword d = new Keyword("foo", "foo", "path");
     assertEquals(c, d);
-    Keyword e = new Keyword("foo", "foo", null);
-    Keyword f = new Keyword("foo", "foo", null);
+    Keyword e = new Keyword("foo", "foo", /*filePath=*/ null);
+    Keyword f = new Keyword("foo", "foo", /*filePath=*/ null);
     assertEquals(e, f);
   }
 
@@ -61,7 +61,7 @@ public class KeywordTest {
     Keyword b = new Keyword("bar");
     assertNotEquals(a, b);
     assertNotEquals(a, null);
-    Keyword c = new Keyword("foo", "foo", null);
+    Keyword c = new Keyword("foo", "foo", /*filePath=*/ null);
     Keyword d = new Keyword("foo", "foo", "path");
     assertNotEquals(c, d);
   }

--- a/buildSrc/subprojects/parser/src/test/resources/integrationTest/expected.ftl
+++ b/buildSrc/subprojects/parser/src/test/resources/integrationTest/expected.ftl
@@ -47,8 +47,8 @@ MORE : {}
 // Auto generated.
 <DEFAULT, DQID, BTID> TOKEN :
 {
-< UNICODE_QUOTED_IDENTIFIER: "U" "&" <QUOTED_IDENTIFIER> > // From: parserTest/identifiers.txt
-| < IDENTIFIER: (<LETTER>|<DOLLAR>) (<LETTER>|<DOLLAR>|<DIGIT>)* > // From: parserTest/intermediate/dialects/testDialect/identifiers.txt
+< IDENTIFIER: (<LETTER>|<DOLLAR>) (<LETTER>|<DOLLAR>|<DIGIT>)* > // From: parserTest/intermediate/dialects/testDialect/identifiers.txt
+| < UNICODE_QUOTED_IDENTIFIER: "U" "&" <QUOTED_IDENTIFIER> > // From: parserTest/identifiers.txt
 }
 
 // Extracted from: parserTest/intermediate/dialects/testDialect/parserImpls.ftl


### PR DESCRIPTION
- All maps that were previously of type Map<Keyword, String> were changed to Map<String, Keyword>
- The type of nonReservedKeywords was changed from Set<Keyword> to Map<String, Keyword> 
- Added `value: String` field to Keyword
- Updated Keyword equals() and hashCode() to use all fields